### PR TITLE
idsnp CDM missmatching json with wrong ID

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.0.12
+- ID-SNPs pairs missmatching fixed. Channel did not keep track of T vs N json
+
 ## v3.0.11
 - patch to fix solid missing lowcov in old coyote
 - when statement for d4-cov

--- a/modules/local/idSnp/main.nf
+++ b/modules/local/idSnp/main.nf
@@ -189,14 +189,15 @@ process PAIRGEN_CDM {
     
     stub:
         def prefix = task.ext.prefix ?: "${meta.id}"
-        
         if(meta.id.size() == 2) {
             tumor_idx   = meta.type.findIndexOf{ it == 'tumor' || it == 'T' }
             normal_idx  = meta.type.findIndexOf{ it == 'normal' || it == 'N' }
             normal_id   = meta.id[normal_idx]
             tumor_id    = meta.id[tumor_idx]
-	        normaljson  = jsons[normal_idx]
-	        tumorjson    = jsons[tumor_idx]
+            tumor_json_idx   = jsons.findIndexOf{ it == 'tumor' || it == 'T' }
+            normal_json_idx   = jsons.findIndexOf{ it == 'normal' || it == 'N' }
+	        normaljson  = jsons[normal_json_idx]
+	        tumorjson    = jsons[tumor_json_idx]
              """
              echo "--overwrite --sample-id ${meta.id[tumor_idx]} --sequencing-run ${meta.sequencing_run[tumor_idx]} --assay ${params.cdm} --id-snp ${params.outdir}/${params.subdir}/QC/${tumorjson} " > ${meta.id[tumor_idx]}.pairgen
              

--- a/modules/local/idSnp/main.nf
+++ b/modules/local/idSnp/main.nf
@@ -90,8 +90,8 @@ process SNP_CHECK {
             echo '{"partner" : "${tumor_id}","sequencing_run" : "${tumor_seq_run}","analysis_date" : "'\${today_date}'" }' > ${normal_id}_partner_info.json
             echo '{"partner" : "${normal_id}","sequencing_run" : "${normal_seq_run}","analysis_date" : "'\${today_date}'" }' > ${tumor_id}_partner_info.json
             
-            combinejsons.py  ${tumor_id}.json ${tumGTjson} --partner_run_json_file  ${tumor_id}_partner_info.json ${tumor_id}.idsnp
-            combinejsons.py  ${normal_id}.json ${norGTjson} --partner_run_json_file ${normal_id}_partner_info.json ${normal_id}.idsnp
+            combinejsons.py  ${tumor_id}.json ${tumGTjson} --partner_run_json_file  ${tumor_id}_partner_info.json ${tumor_id}.T.idsnp
+            combinejsons.py  ${normal_id}.json ${norGTjson} --partner_run_json_file ${normal_id}_partner_info.json ${normal_id}.N.idsnp
         
             cat <<-END_VERSIONS > versions.yml
             "${task.process}":
@@ -102,7 +102,7 @@ process SNP_CHECK {
             """
             echo "Not applicable" > s${tumor_id}.csv
             echo  '{ "is_paired_sample" : false}' > ${tumor_id}.json
-            combinejsons.py  ${tumor_id}.json ${tumGTjson} ${tumor_id}.idsnp
+            combinejsons.py  ${tumor_id}.json ${tumGTjson} ${tumor_id}.T.idsnp
             
             cat <<-END_VERSIONS > versions.yml
             "${task.process}":
@@ -165,8 +165,10 @@ process PAIRGEN_CDM {
         normal_idx  = meta.type.findIndexOf{ it == 'normal' || it == 'N' }
         normal_id   = meta.id[normal_idx]
         tumor_id    = meta.id[tumor_idx]
-	    normaljson  = jsons[normal_idx]
-	    tumorjson    = jsons[tumor_idx]
+        tumor_json_idx   = jsons.findIndexOf{ it == 'tumor' || it == 'T' }
+        normal_json_idx   = jsons.findIndexOf{ it == 'normal' || it == 'N' }
+	    normaljson  = jsons[normal_json_idx]
+	    tumorjson    = jsons[tumor_json_idx]
 
         """
         echo "--overwrite --sample-id ${meta.id[tumor_idx]} --sequencing-run ${meta.sequencing_run[tumor_idx]} --assay ${params.cdm} --id-snp ${params.outdir}/${params.subdir}/QC/${tumorjson} " > ${meta.id[tumor_idx]}.pairgen

--- a/modules/local/idSnp/main.nf
+++ b/modules/local/idSnp/main.nf
@@ -198,10 +198,10 @@ process PAIRGEN_CDM {
             normal_json_idx   = jsons.findIndexOf{ it == 'normal' || it == 'N' }
 	        normaljson  = jsons[normal_json_idx]
 	        tumorjson    = jsons[tumor_json_idx]
-             """
-             echo "--overwrite --sample-id ${meta.id[tumor_idx]} --sequencing-run ${meta.sequencing_run[tumor_idx]} --assay ${params.cdm} --id-snp ${params.outdir}/${params.subdir}/QC/${tumorjson} " > ${meta.id[tumor_idx]}.pairgen
-             
-             echo "--overwrite --sample-id ${meta.id[normal_idx]} --sequencing-run ${meta.sequencing_run[normal_idx]} --assay ${params.cdm} --id-snp ${params.outdir}/${params.subdir}/QC/${normaljson} "> ${meta.id[normal_idx]}.pairgen
+            """
+            echo "--overwrite --sample-id ${meta.id[tumor_idx]} --sequencing-run ${meta.sequencing_run[tumor_idx]} --assay ${params.cdm} --id-snp ${params.outdir}/${params.subdir}/QC/${tumorjson} " > ${meta.id[tumor_idx]}.pairgen
+            
+            echo "--overwrite --sample-id ${meta.id[normal_idx]} --sequencing-run ${meta.sequencing_run[normal_idx]} --assay ${params.cdm} --id-snp ${params.outdir}/${params.subdir}/QC/${normaljson} "> ${meta.id[normal_idx]}.pairgen
             """
         } else {
             tumor_idx   = meta.type.findIndexOf{ it == 'tumor' || it == 'T' }

--- a/modules/local/idSnp/main.nf
+++ b/modules/local/idSnp/main.nf
@@ -120,8 +120,8 @@ process SNP_CHECK {
         if(meta.id.size() == 2) {
             """ 
             touch s${tumor_id}_c${normal_id}.csv
-            touch ${tumor_id}.idsnp
-            touch ${normal_id}.idsnp
+            touch ${tumor_id}.T.idsnp
+            touch ${normal_id}.N.idsnp
 
 
             cat <<-END_VERSIONS > versions.yml
@@ -134,7 +134,7 @@ process SNP_CHECK {
             """
             echo "Not applicable" > s${tumor_id}.csv
             echo  '{ "is_paired_sample" : false }' > ${tumor_id}.json
-            touch ${tumor_id}.idsnp
+            touch ${tumor_id}.T.idsnp
 
             cat <<-END_VERSIONS > versions.yml
             "${task.process}":

--- a/subworkflows/local/bam_qc.nf
+++ b/subworkflows/local/bam_qc.nf
@@ -39,7 +39,7 @@ workflow BAM_QC {
         SNP_CHECK(ALLELE_CALL.out.sample_id_genotypes.groupTuple())
         ch_versions = ch_versions.mix(SNP_CHECK.out.versions)
 
-        PAIRGEN_CDM (SNP_CHECK.out.idsnp_checked)
+        PAIRGEN_CDM (SNP_CHECK.out.idsnp_checked.view())
 
         // // Calculate cross-sample contamination
         // VERIFYBAMID { bam_umi }

--- a/subworkflows/local/bam_qc.nf
+++ b/subworkflows/local/bam_qc.nf
@@ -39,7 +39,7 @@ workflow BAM_QC {
         SNP_CHECK(ALLELE_CALL.out.sample_id_genotypes.groupTuple())
         ch_versions = ch_versions.mix(SNP_CHECK.out.versions)
 
-        PAIRGEN_CDM (SNP_CHECK.out.idsnp_checked.view())
+        PAIRGEN_CDM (SNP_CHECK.out.idsnp_checked)
 
         // // Calculate cross-sample contamination
         // VERIFYBAMID { bam_umi }


### PR DESCRIPTION
Added a T/N identifier to idsnp-json to make it indexable. Can now be properly matched with correct ID in CDM load.