### PR TITLE
reverted rescuing of clinvar pathogenic vars

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 ## Changelog ##
 
+## 3.0.17
+- reverted clinsig rescue for failed variants
+
 ## 3.0.16
 - updated solid msi loci
 

--- a/configs/modules/snv_annotate.config
+++ b/configs/modules/snv_annotate.config
@@ -114,6 +114,6 @@ process {
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
 
-        ext.args    = { "--max_freq ${params.filter_freq} --filters ${params.filter_field_filter} --override_key_values ${params.override_filter_terms}" }
+        ext.args    = { "--max_freq ${params.filter_freq} --filters ${params.filter_field_filter}" }
     }
 }


### PR DESCRIPTION
Dont override rules for failed variants. NVAF not rescued by clinvar patho/likely patho